### PR TITLE
fix compatibility with godot 3.3

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -25,7 +25,6 @@ sources = [
 use_shared_libs = ARGUMENTS.get('slicer_shared', 'no') == 'yes'
 
 module_env = env.Clone()
-module_env.Append(CXXFLAGS=['-std=c++11'])
 
 # Build the plugin as a shared library for faster builds
 def configure_shared_lib_build():


### PR DESCRIPTION
configuration `module_env.Append(CXXFLAGS=['-std=c++11'])` in SCsub is not required anymore, as godot uses C++14 by default now